### PR TITLE
Fix folder paths

### DIFF
--- a/src/Core/GlobalFunctions.py
+++ b/src/Core/GlobalFunctions.py
@@ -24,12 +24,12 @@ def set_ARGS_PARSER():
 def set_FOLDERS():
     GV.FOLDERNAME_ALBUMS            = GV.ARGS.get('foldername-albums')                          or GV.FOLDERNAME_ALBUMS
     GV.FOLDERNAME_NO_ALBUMS         = GV.ARGS.get('foldername-no-albums')                       or GV.FOLDERNAME_NO_ALBUMS
-    GV.FOLDERNAME_GPTH              = os.path.abspath(GV.ARGS.get('exec-gpth-tool'))            or os.path.abspath(GV.FOLDERNAME_GPTH)
-    GV.FOLDERNAME_EXIFTOOL          = os.path.abspath(GV.ARGS.get('exec-exif-tool'))            or os.path.abspath(GV.FOLDERNAME_EXIFTOOL)
-    GV.CONFIGURATION_FILE           = resolve_path(GV.ARGS.get('configuration-file'))           or resolve_path(GV.CONFIGURATION_FILE)
-    GV.FOLDERNAME_EXIFTOOL_OUTPUT   = resolve_path(GV.ARGS.get('foldername-exiftool-output'))   or resolve_path(GV.FOLDERNAME_EXIFTOOL_OUTPUT)
-    GV.FOLDERNAME_DUPLICATES_OUTPUT = resolve_path(GV.ARGS.get('foldername-duplicates-output')) or resolve_path(GV.FOLDERNAME_DUPLICATES_OUTPUT)
-    GV.FOLDERNAME_LOGS              = resolve_path(GV.ARGS.get('foldername-logs'))              or resolve_path(GV.FOLDERNAME_LOGS)
+    GV.FOLDERNAME_GPTH              = os.path.abspath(GV.ARGS.get('exec-gpth-tool')             or GV.FOLDERNAME_GPTH)
+    GV.FOLDERNAME_EXIFTOOL          = os.path.abspath(GV.ARGS.get('exec-exif-tool')             or GV.FOLDERNAME_EXIFTOOL)
+    GV.CONFIGURATION_FILE           = resolve_path(GV.ARGS.get('configuration-file')            or GV.CONFIGURATION_FILE)
+    GV.FOLDERNAME_EXIFTOOL_OUTPUT   = resolve_path(GV.ARGS.get('foldername-exiftool-output')    or GV.FOLDERNAME_EXIFTOOL_OUTPUT)
+    GV.FOLDERNAME_DUPLICATES_OUTPUT = resolve_path(GV.ARGS.get('foldername-duplicates-output')  or GV.FOLDERNAME_DUPLICATES_OUTPUT)
+    GV.FOLDERNAME_LOGS              = resolve_path(GV.ARGS.get('foldername-logs')               or GV.FOLDERNAME_LOGS)
 
 
 def set_LOGGER():


### PR DESCRIPTION
`os.path.abspath` returned a non-empty `/app` string even when `GV.ARGS.get(...)` has an empty output, leading to the function picking the first option even when it should not. This PR moves the `or` inside the function to solve this. There was no such issue for `resolve_path` at the moment, but I did the same change there for consistency and to avoid something like this in the future.

Note, that with this change it's also feasible to switch back to using `resolve_path` for the executable paths, if we want to.

Hopefully fixes #632.