### PR TITLE
Bug fix file_path variable name and typo fix

### DIFF
--- a/src/Features/SynologyPhotos/ClassSynologyPhotos.py
+++ b/src/Features/SynologyPhotos/ClassSynologyPhotos.py
@@ -2063,7 +2063,7 @@ class ClassSynologyPhotos:
                         asset_id, is_dup = self.push_asset(file_, log_level=logging.WARNING)
                         if is_dup:
                             total_duplicated_assets_skipped += 1
-                            LOGGER.debug(f"Dupplicated Asset: {file_path}. Asset ID: {asset_id} skipped")
+                            LOGGER.debug(f"Duplicated Asset: {file_}. Asset ID: {asset_id} skipped")
                         elif asset_id:
                             LOGGER.debug(f"Asset ID: {asset_id} uploaded to Immich Photos")
                             total_assets_uploaded += 1


### PR DESCRIPTION
Fix for variable name used in debug logging that caused a critical error at runtime.

_Please note: though I tried to get unit tests running to test this, I was not able to.  This is due to my lack of knowledge of Python. So please review, test and merge with great caution. Literally the 1st Python PR in my life :-)._