### PR TITLE
fix: stream Immich multipart upload to avoid OOM

### DIFF
--- a/src/Features/ImmichPhotos/ClassImmichPhotos.py
+++ b/src/Features/ImmichPhotos/ClassImmichPhotos.py
@@ -6,13 +6,16 @@ import logging
 import os
 import sys
 import time
+from contextlib import ExitStack
 from datetime import datetime
 from urllib.parse import urlparse
 
+import mimetypes
 import requests
 import urllib3
 from dateutil import parser
 from halo import Halo
+from requests_toolbelt.multipart.encoder import MultipartEncoder
 from tabulate import tabulate
 
 from Core.CustomLogger import set_log_level
@@ -1170,20 +1173,6 @@ class ClassImmichPhotos:
                     return None, None
 
             url = f"{self.IMMICH_URL}/api/assets"
-            files = {
-                'assetData': open(file_path, 'rb')
-            }
-
-            # Check for sidecar in the same path
-            for sidecar_extension in self.ALLOWED_IMMICH_SIDECAR_EXTENSIONS:
-                sidecar_path_1 = f"{file_path}{sidecar_extension}"
-                sidecar_path_2 = file_path.replace(ext, sidecar_extension)
-                if os.path.isfile(sidecar_path_1):
-                    files['sidecarData'] = open(sidecar_path_1, 'rb')
-                    break
-                elif os.path.isfile(sidecar_path_2):
-                    files['sidecarData'] = open(sidecar_path_2, 'rb')
-                    break
 
             stats = os.stat(file_path)
             try:
@@ -1218,9 +1207,40 @@ class ClassImmichPhotos:
                 }
 
             try:
-                response = requests.post(url, headers=header, data=data, files=files)
-                response.raise_for_status()
-                new_asset = response.json()
+                with ExitStack() as stack:
+                    file_obj = stack.enter_context(open(file_path, "rb"))
+                    mime_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+
+                    fields = {
+                        "deviceAssetId": data["deviceAssetId"],
+                        "deviceId": data["deviceId"],
+                        "fileCreatedAt": data["fileCreatedAt"],
+                        "fileModifiedAt": data["fileModifiedAt"],
+                        "fileSize": data["fileSize"],
+                        "isFavorite": data["isFavorite"],
+                        "isVisible": data["isVisible"],
+                        "assetData": (os.path.basename(file_path), file_obj, mime_type),
+                    }
+
+                    for sidecar_extension in self.ALLOWED_IMMICH_SIDECAR_EXTENSIONS:
+                        sidecar_path_1 = f"{file_path}{sidecar_extension}"
+                        sidecar_path_2 = file_path.replace(ext, sidecar_extension)
+                        if os.path.isfile(sidecar_path_1):
+                            sidecar_obj = stack.enter_context(open(sidecar_path_1, "rb"))
+                            sidecar_mime = mimetypes.guess_type(sidecar_path_1)[0] or "application/octet-stream"
+                            fields["sidecarData"] = (os.path.basename(sidecar_path_1), sidecar_obj, sidecar_mime)
+                            break
+                        elif os.path.isfile(sidecar_path_2):
+                            sidecar_obj = stack.enter_context(open(sidecar_path_2, "rb"))
+                            sidecar_mime = mimetypes.guess_type(sidecar_path_2)[0] or "application/octet-stream"
+                            fields["sidecarData"] = (os.path.basename(sidecar_path_2), sidecar_obj, sidecar_mime)
+                            break
+
+                    multipart_data = MultipartEncoder(fields=fields)
+                    header["Content-Type"] = multipart_data.content_type
+                    response = requests.post(url, headers=header, data=multipart_data)
+                    response.raise_for_status()
+                    new_asset = response.json()
                 asset_id = new_asset.get("id")
                 is_duplicated = (new_asset.get("status") == 'duplicate')
                 if asset_id:

--- a/tests/test_immich_upload_streaming.py
+++ b/tests/test_immich_upload_streaming.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from requests_toolbelt.multipart.encoder import MultipartEncoder
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from Features.ImmichPhotos.ClassImmichPhotos import ClassImmichPhotos
+
+
+class TestImmichStreamingUpload(unittest.TestCase):
+    def _build_manager(self):
+        manager = ClassImmichPhotos.__new__(ClassImmichPhotos)
+        manager.ALLOWED_IMMICH_MEDIA_EXTENSIONS = [".jpg"]
+        manager.ALLOWED_IMMICH_SIDECAR_EXTENSIONS = [".xmp"]
+        manager.IMMICH_URL = "http://immich.local"
+        manager.API_KEY_LOGIN = True
+        manager.IMMICH_USER_API_KEY = "test-api-key"
+        manager.SESSION_TOKEN = None
+        manager.login = lambda log_level=None: True
+        return manager
+
+    @patch("Features.ImmichPhotos.ClassImmichPhotos.LOGGER", new_callable=MagicMock)
+    @patch("Features.ImmichPhotos.ClassImmichPhotos.requests.post")
+    def test_push_asset_uses_streaming_multipart_without_files_arg(
+        self, mock_post, _mock_logger
+    ):
+        manager = self._build_manager()
+
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"id": "asset-id", "status": "created"}
+        mock_post.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_path = os.path.join(tmpdir, "photo.jpg")
+            with open(asset_path, "wb") as f:
+                f.write(b"binary-data")
+
+            asset_id, is_duplicated = manager.push_asset(asset_path)
+
+        self.assertEqual(asset_id, "asset-id")
+        self.assertFalse(is_duplicated)
+
+        kwargs = mock_post.call_args.kwargs
+        self.assertNotIn("files", kwargs)
+        self.assertIsInstance(kwargs["data"], MultipartEncoder)
+        self.assertIn("multipart/form-data", kwargs["headers"]["Content-Type"])
+
+    @patch("Features.ImmichPhotos.ClassImmichPhotos.LOGGER", new_callable=MagicMock)
+    @patch("Features.ImmichPhotos.ClassImmichPhotos.requests.post")
+    def test_push_asset_attaches_sidecar_in_multipart_fields(
+        self, mock_post, _mock_logger
+    ):
+        manager = self._build_manager()
+
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"id": "asset-id", "status": "created"}
+        mock_post.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_path = os.path.join(tmpdir, "photo.jpg")
+            sidecar_path = os.path.join(tmpdir, "photo.xmp")
+            with open(asset_path, "wb") as f:
+                f.write(b"binary-data")
+            with open(sidecar_path, "wb") as f:
+                f.write(b"sidecar-data")
+
+            manager.push_asset(asset_path)
+
+        encoder = mock_post.call_args.kwargs["data"]
+        self.assertIn("sidecarData", encoder.fields)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR updates Immich asset uploads to use streamed multipart encoding to prevent high memory usage (and potential OOM) during uploads.

Closes #1033

## Problem

Uploads to Immich were sent via `requests.post(..., files=...)` in `ClassImmichPhotos.push_asset(...)`.  
With large files and/or concurrent uploads, multipart payload handling could cause excessive RAM usage.

## Changes

- Switched Immich upload implementation in `push_asset` to streamed multipart using `MultipartEncoder`
- Kept existing upload metadata fields and duplicate handling behavior unchanged
- Preserved optional sidecar upload support
- Ensured file handles are safely managed during upload (`ExitStack`)

## Scope / Impact

This affects all upload flows that call `ClassImmichPhotos.push_asset(...)`, including:

- automatic migration uploads to Immich
- album uploads
- no-album uploads

## Tests

- Added focused regression tests:
  - `tests/test_immich_upload_streaming.py`
  - verifies multipart streaming is used
  - verifies no `files=` argument is used
  - verifies sidecar inclusion still works
- Ran:
  - `uv run python -m unittest tests.test_immich_upload_streaming` ✅
  - `uv run python -m unittest` (contains existing unrelated baseline failures)
