### PR TITLE
Fix Immich v3 API compatibility (album owner + album assets)

### DIFF
--- a/src/Features/ImmichPhotos/ClassImmichPhotos.py
+++ b/src/Features/ImmichPhotos/ClassImmichPhotos.py
@@ -445,6 +445,30 @@ class ClassImmichPhotos:
                 return False
 
 
+    @staticmethod
+    def _get_album_owner_id(album):
+        """
+        Return the owner user id of an album, compatible with all Immich versions.
+
+        Immich <= v2 exposes 'ownerId' directly on the album object. Immich v3 removed
+        'ownerId' (and the 'owner' object) from AlbumResponseDto and moved that information
+        into 'albumUsers' as the entry whose role is 'owner'.
+
+        Args:
+            album (dict): Album object as returned by the Immich API.
+
+        Returns:
+            str: The owner user id, or None if it cannot be determined.
+        """
+        owner_id = album.get('ownerId')
+        if owner_id:
+            return owner_id
+        for album_user in album.get('albumUsers', []) or []:
+            if album_user.get('role') == 'owner':
+                return (album_user.get('user') or {}).get('id')
+        return None
+
+
     def get_albums_owned_by_user(self, filter_assets=True, log_level=None):
         """
         Get all albums in Immich Photos for the current user.
@@ -473,7 +497,7 @@ class ClassImmichPhotos:
                 user_id = self.get_user_id(log_level=logging.WARNING)
                 albums_filtered = []
                 for album in albums:
-                    if album.get('ownerId') == user_id:
+                    if self._get_album_owner_id(album) == user_id:
                         album_id = album.get('id')
                         album_name = album.get("albumName", "")
                         if filter_assets and has_any_filter():
@@ -936,6 +960,41 @@ class ClassImmichPhotos:
             return all_filtered_assets
 
 
+    def _get_album_assets_via_search(self, album_id, log_level=None):
+        """
+        Retrieve all assets of an album using 'POST /api/search/metadata' filtered by
+        'albumIds', paginating through the results.
+
+        This is required for Immich v3+, where the 'assets' property was removed from
+        AlbumResponseDto (i.e. 'GET /api/albums/{id}' no longer returns the album's assets).
+        It also works on older Immich versions, so it is safe to use as a fallback.
+
+        Args:
+            album_id (str): ID of the album.
+            log_level (logging.LEVEL): log_level for logs and console
+
+        Returns:
+            list: Raw asset dicts belonging to the album ([] if none / on error).
+        """
+        with set_log_level(LOGGER, log_level):
+            self.login(log_level=log_level)
+            url = f"{self.IMMICH_URL}/api/search/metadata"
+            album_assets = []
+            next_page = 1
+            try:
+                while True:
+                    payload = json.dumps({"albumIds": [album_id], "page": next_page, "order": "desc"})
+                    resp = requests.post(url, headers=self.HEADERS_WITH_CREDENTIALS, data=payload, verify=False)
+                    resp.raise_for_status()
+                    data = resp.json()
+                    album_assets.extend(data.get("assets", {}).get("items", []))
+                    next_page = data.get("assets", {}).get("nextPage", None)
+                    if next_page is None:
+                        break
+            except Exception as e:
+                LOGGER.error(f"Failed to retrieve assets from album ID={album_id} via search: {str(e)}")
+            return album_assets
+
     def get_all_assets_from_album(self, album_id, album_name=None, log_level=None):
         """
         Get assets in a specific album.
@@ -955,7 +1014,14 @@ class ClassImmichPhotos:
                 resp = requests.get(url, headers=self.HEADERS_WITH_CREDENTIALS, verify=False)
                 resp.raise_for_status()
                 data = resp.json()
-                album_assets = data.get("assets", [])
+                # Immich <= v2 returns the album's assets inline in AlbumResponseDto.
+                # Immich v3 removed the 'assets' property from GET /api/albums/{id}, so fall
+                # back to POST /api/search/metadata (filtered by albumIds) to fetch them. The
+                # inline path is kept for backward compatibility with older Immich servers.
+                if isinstance(data.get("assets"), list):
+                    album_assets = data.get("assets", [])
+                else:
+                    album_assets = self._get_album_assets_via_search(album_id, log_level=log_level)
                 # Add new fields "time" with the same value as "fileCreatedAt" and "filename" with the same value as "originalFileName" to allign with Synology Photos
                 for asset in album_assets:
                     asset["time"] = asset["fileCreatedAt"]
@@ -992,7 +1058,14 @@ class ClassImmichPhotos:
                 resp = requests.get(url, headers=self.HEADERS_WITH_CREDENTIALS, verify=False)
                 resp.raise_for_status()
                 data = resp.json()
-                album_assets = data.get("assets", [])
+                # Immich <= v2 returns the album's assets inline in AlbumResponseDto.
+                # Immich v3 removed the 'assets' property from GET /api/albums/{id}, so fall
+                # back to POST /api/search/metadata (filtered by albumIds) to fetch them. The
+                # inline path is kept for backward compatibility with older Immich servers.
+                if isinstance(data.get("assets"), list):
+                    album_assets = data.get("assets", [])
+                else:
+                    album_assets = self._get_album_assets_via_search(album_id, log_level=log_level)
                 # Add new fields "time" with the same value as "fileCreatedAt" and "filename" with the same value as "originalFileName" to allign with Synology Photos
                 for asset in album_assets:
                     asset["time"] = asset["fileCreatedAt"]

--- a/src/Features/ImmichPhotos/ClassImmichPhotos.py
+++ b/src/Features/ImmichPhotos/ClassImmichPhotos.py
@@ -497,7 +497,10 @@ class ClassImmichPhotos:
                 user_id = self.get_user_id(log_level=logging.WARNING)
                 albums_filtered = []
                 for album in albums:
-                    if self._get_album_owner_id(album) == user_id:
+                    owner_id = self._get_album_owner_id(album)
+                    # Guard against None == None: if neither the album owner nor the current
+                    # user id can be determined, do not treat the album as owned by the user.
+                    if owner_id is not None and owner_id == user_id:
                         album_id = album.get('id')
                         album_name = album.get("albumName", "")
                         if filter_assets and has_any_filter():
@@ -974,25 +977,30 @@ class ClassImmichPhotos:
             log_level (logging.LEVEL): log_level for logs and console
 
         Returns:
-            list: Raw asset dicts belonging to the album ([] if none / on error).
+            list: Raw asset dicts belonging to the album ([] if the album is empty).
+
+        Raises:
+            Exception: Request/HTTP errors are intentionally propagated (not swallowed)
+                so the caller treats a partially-paginated album as a failure and returns
+                [] with an error, rather than silently returning a truncated list that
+                looks complete.
         """
         with set_log_level(LOGGER, log_level):
             self.login(log_level=log_level)
             url = f"{self.IMMICH_URL}/api/search/metadata"
             album_assets = []
             next_page = 1
-            try:
-                while True:
-                    payload = json.dumps({"albumIds": [album_id], "page": next_page, "order": "desc"})
-                    resp = requests.post(url, headers=self.HEADERS_WITH_CREDENTIALS, data=payload, verify=False)
-                    resp.raise_for_status()
-                    data = resp.json()
-                    album_assets.extend(data.get("assets", {}).get("items", []))
-                    next_page = data.get("assets", {}).get("nextPage", None)
-                    if next_page is None:
-                        break
-            except Exception as e:
-                LOGGER.error(f"Failed to retrieve assets from album ID={album_id} via search: {str(e)}")
+            while True:
+                # Immich returns 'nextPage' as a string, but 'page' is validated as an
+                # integer (strictly, under v3's Zod validation), so coerce before sending.
+                payload = json.dumps({"albumIds": [album_id], "page": int(next_page), "order": "desc"})
+                resp = requests.post(url, headers=self.HEADERS_WITH_CREDENTIALS, data=payload, verify=False)
+                resp.raise_for_status()
+                data = resp.json()
+                album_assets.extend(data.get("assets", {}).get("items", []))
+                next_page = data.get("assets", {}).get("nextPage", None)
+                if next_page is None:
+                    break
             return album_assets
 
     def get_all_assets_from_album(self, album_id, album_name=None, log_level=None):


### PR DESCRIPTION
## Summary

Immich **v3.0.0** (released 2026-07-02) shipped [breaking API changes](https://immich.app/blog/v3-migration) that affect third-party integrations. Two of them silently break album migration in `ClassImmichPhotos` when the target/source server is on v3 — no exception is raised, albums just come across **empty** or **not owned**, which is easy to miss.

This PR makes the Immich client compatible with **both** pre-v3 and v3 servers. Everything was verified against the [v3.0.0 OpenAPI spec](https://github.com/immich-app/immich/blob/v3.0.0/open-api/immich-openapi-specs.json) and the existing pre-v3 behavior.

## The two breakages

**1. `ownerId` removed from `AlbumResponseDto`**
`get_albums_owned_by_user()` filtered on `album.get('ownerId')`. In v3 that field is gone (owner moved into `albumUsers` as the entry with role `owner`), so the filter matched nothing and the user's owned albums were skipped entirely.

**2. `assets` removed from `GET /api/albums/{id}`**
`get_all_assets_from_album()` / `get_all_assets_from_album_shared()` read `data.get("assets", [])` from the album response. In v3 the `assets` property was removed (`GET /api/albums/{id}` no longer returns assets), so these returned `[]` and albums migrated with **zero assets**.

## The fix (backward compatible)

- **`_get_album_owner_id(album)`** — prefers `ownerId` (≤ v2) and falls back to the `albumUsers` entry whose `role == 'owner'` (v3). `albumUsers` is present on both versions, and `AlbumUserRole` includes `owner` in the v3 spec.
- **`_get_album_assets_via_search(album_id)`** — fetches an album's assets via `POST /api/search/metadata` filtered by `albumIds` (the replacement documented in the v3 migration guide; `MetadataSearchDto.albumIds` also exists pre-v3). Paginates using the same `assets.items` / `assets.nextPage` shape already used elsewhere in this file.
- The inline `assets` path is **kept** for ≤ v2 and only used as the fast path; the code falls back to search only when `assets` is absent (`isinstance(data.get("assets"), list)` check), so older servers are unaffected and make no extra request.

## Scope / notes

- No public method signatures change; callers are untouched.
- Other v3 API changes (e.g. `deviceId`/`deviceAssetId` removal on upload, `number` → `integer` typing, Zod error-response shape) were reviewed but are not used in a way that breaks this client. Happy to follow up if you'd like those hardened too.
- `python -m py_compile` passes. I don't have a v3 server in CI reach, so a maintainer smoke-test against a real v3 instance would be worthwhile before release.
- Let me know if you'd like a `CHANGELOG.md` entry in your preferred format and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
