### PR TITLE
Add correct PhotoMigrator web app icon

### DIFF
--- a/src/web_interface/html/_main_app_page.html
+++ b/src/web_interface/html/_main_app_page.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PhotoMigrator Web Interface</title>
     <link rel="icon" href="/assets/ico/PhotoMigrator.ico" sizes="any">
+    <link rel="apple-touch-icon" href="/assets/logos/logo_17_1024x1024.png?v=1">
     <link rel="stylesheet" href="/static/style.css?v=20260721-header-collapse-spacing">
 </head>
 <body data-theme="{{ initial_theme }}">

--- a/src/web_interface/html/admin.html
+++ b/src/web_interface/html/admin.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ tool_name }} Admin</title>
     <link rel="icon" href="/assets/ico/PhotoMigrator.ico" sizes="any">
+    <link rel="apple-touch-icon" href="/assets/logos/logo_17_1024x1024.png?v=1">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="admin-page">

--- a/src/web_interface/html/doc_view.html
+++ b/src/web_interface/html/doc_view.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ tool_name }} Docs</title>
     <link rel="icon" href="/assets/ico/PhotoMigrator.ico" sizes="any">
+    <link rel="apple-touch-icon" href="/assets/logos/logo_17_1024x1024.png?v=1">
     <style>
         :root {
             color-scheme: light;

--- a/src/web_interface/html/login.html
+++ b/src/web_interface/html/login.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ tool_name }} Login</title>
     <link rel="icon" href="/assets/ico/PhotoMigrator.ico" sizes="any">
+    <link rel="apple-touch-icon" href="/assets/logos/logo_17_1024x1024.png?v=1">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body class="login-page" data-theme="ocean">


### PR DESCRIPTION
Adds an `apple-touch-icon` to every PhotoMigrator web-interface page. This makes iPhone/iPad use the PhotoMigrator logo when the site is added to the Home Screen.